### PR TITLE
copy operator= fix & extra tests

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all : mvector_example1 mvector_example2 mvector_example_c++0x
+all : mvector_example1 mvector_example2 mvector_example_c++0x mvector_test
 
 CXX = g++
 CXXFLAGS = -Wall -g -O3 -I.. -std=c++0x
@@ -12,6 +12,9 @@ mvector_example2 : mvector_example2.cpp ../mvector.hpp
 
 mvector_example_c++0x : mvector_example_c++0x.cpp ../mvector.hpp
 	$(CXX) $(CXXFLAGS) mvector_example_c++0x.cpp -o mvector_example_c++0x
+	
+mvector_test : mvector_test.cpp ../mvector.hpp
+	$(CXX) $(CXXFLAGS) mvector_test.cpp -o mvector_test
 
 clean:
-	rm mvector_example1 mvector_example2 mvector_example_c++0x
+	rm mvector_example1 mvector_example2 mvector_example_c++0x mvector_test

--- a/examples/mvector_test.cpp
+++ b/examples/mvector_test.cpp
@@ -1,38 +1,100 @@
 #include "mvector.hpp"
-#include <cassert>
 #include <iostream>
+#include <exception>
+#include <cassert>
 
-// print message separately before the failed assertion, re-evaluate assert to display line number and file details
-#define ASSERT(test, msg) if(!test) { std::cerr << msg << std::endl; assert(test); }
+// print message separately before exit, re-evaluate assert to display line number and file details
+#define ASSERT_MSG(test, msg) if(!(test)) { std::cerr << msg << std::endl; assert(test); }
 
-void main()
+int main()
 {
     std::vector<double> v11 = { 1, 2, 3 };
+    std::vector<double> v21 = { 6, 5, 4 };
     xstd::mvector<1, double> mv1 = v11;
     std::vector<double> v12 = mv1;
-    ASSERT(mv1.size() == 3 && mv1[0] == 1 && mv1[1] == 2 && mv1[2] == 3, "Failed mvector<1,T> assign with vector<T> =operator");
-    ASSERT(v12.size() == 3 && v12[0] == 1 && v12[1] == 2 && v12[2] == 3, "Failed vector<T> assign with mvector<1,T> =operator");
-    
-    xstd::mvector<2, double> mv2({1, 3}), mv3;
+    ASSERT_MSG(mv1.size() == 3 && mv1[0] == 1 && mv1[1] == 2 && mv1[2] == 3, "Failed mvector<1,T> assign with vector<T> =operator");
+    ASSERT_MSG(v12.size() == 3 && v12[0] == 1 && v12[1] == 2 && v12[2] == 3, "Failed vector<T> assign with mvector<1,T> =operator");    
+    xstd::mvector<2, double> mv2({1, 3}), mv3({2, 3});
+    xstd::mvector<2, double> mv4, mv5, mv6, mv7;    
     mv2[0] = v11;
-    mv3.push_back(v11);
+    mv3[0] = v21;
+    mv3[1] = v11;
+    mv4 = xstd::mvector<2, double>({2, 3});
+    mv4[1] = v21;
+    mv5 = xstd::mvector<2, double>({3, 0});
+    xstd::mvector<1, double> mv52(3);
+    mv52[0] = 7;
+    mv52[1] = 8;
+    mv52[2] = 9;    
+    ASSERT_MSG(mv2.size() == 1 && mv2[0].size() == 3 && mv2[0][0] == 1 && mv2[0][1] == 2 && mv2[0][2] == 3, 
+               "Failed mvector<2,T> indexed assign with vector<T> =operator");
+    ASSERT_MSG(mv3.size() == 2 && mv3[0].size() == 3 && mv3[1].size() == 3 && 
+               mv3[0][0] == 6 && mv3[0][1] == 5 && mv3[0][2] == 4 &&
+               mv3[1][0] == 1 && mv3[1][1] == 2 && mv3[1][2] == 3, 
+               "Failed to fully assign mvector<2,T> sub-vectors from vector<T> instances");
+    ASSERT_MSG(mv4.size() == 2 && mv4[0].size() == 3 && mv4[1].size() == 3, 
+               "Failed to properly initialized mvector<2,T> specified dimensions although not all assigned yet");
+    ASSERT_MSG(mv4[0][0] == 0 && mv4[0][1] == 0 && mv4[0][2] == 0 &&
+               mv4[1][0] == 6 && mv4[1][1] == 5 && mv4[1][2] == 4, 
+               "Failed to partially assign mvector<2,T> sub-vector from vector<T> instance, other left to default");
+    ASSERT_MSG(mv5.size() == 3 && mv5[0].size() == 0 && mv5[1].size() == 0 && mv5[2].size() == 0, 
+               "Failed mvector<2,T> default empty size when not yet assigned and size=0");
+    mv5[1] = mv52;
+    ASSERT_MSG(mv5.size() == 3 && mv5[0].size() == 0 && mv5[1].size() == 3 && mv5[2].size() == 0, 
+               "Failed mvector<2,T> size when only partially assigned");
+    mv5[0] = std::vector<double>{ 9, 7, 5, 3, 1 };    
+    mv5[2] = std::vector<double>(2, 1);
+    ASSERT_MSG(mv5.size() == 3 && mv5[0].size() == 5 && mv5[1].size() == 3 && mv5[2].size() == 2, 
+               "Failed mvector<2,T> element assign with different size and type vectors");
+    ASSERT_MSG(mv5[0][0] == 9 && mv5[0][1] == 7 && mv5[0][2] == 5 && mv5[0][3] == 3 && mv5[0][4] == 1, 
+               "Failed mvector<2,T> element assign with iterator");
+    ASSERT_MSG(mv5[1][0] == 7 && mv5[1][1] == 8 && mv5[1][2] == 9, 
+               "Failed mvector<2,T> element assign with iterator");
+    ASSERT_MSG(mv5[2][0] == 1 && mv5[2][1] == 1, 
+               "Failed mvector<2,T> element assign with vector<T> constructor");
+    mv6 = mv3;
+    ASSERT_MSG(mv6.size() == 2 && mv6[0].size() == 3 && mv6[1].size() == 3 && 
+               mv6[0][0] == 6 && mv6[0][1] == 5 && mv6[0][2] == 4 &&
+               mv6[1][0] == 1 && mv6[1][1] == 2 && mv6[1][2] == 3, 
+               "Failed mvector<2,T> copy constructor from other mvector<2,T>");
+    ASSERT_MSG(mv7.size() == 0, 
+               "Failed to initialize mvector<2,T> to default empty size");
+    mv7.push_back(v21);
+    ASSERT_MSG(mv7.size() == 1 && mv7[0].size() == 3 &&
+               mv7[0][0] == 6 && mv7[0][1] == 5 && mv7[0][2] == 4, 
+               "Failed mvector<2,T> inserting with vector<T> push_back");  
+    mv7.push_back(mv5[0]);
+    ASSERT_MSG(mv7.size() == 2 && mv7[0].size() == 3 && mv7[1].size() == 5 &&                
+               mv7[0][0] == 6 && mv7[0][1] == 5 && mv7[0][2] == 4 &&
+               mv7[1][0] == 9 && mv7[1][1] == 7 && mv7[1][2] == 5 && mv7[1][3] == 3 && mv7[1][4] == 1, 
+               "Failed mvector<2,T> inserting with different size vector<T> push_back");        
+    mv7.push_back(mv5[1]);
+    ASSERT_MSG(mv7.size() == 3 && mv7[0].size() == 3 && mv7[1].size() == 5 && mv7[2].size() == 3 &&
+               mv7[0][0] == 6 && mv7[0][1] == 5 && mv7[0][2] == 4 &&
+               mv7[1][0] == 9 && mv7[1][1] == 7 && mv7[1][2] == 5 && mv7[1][3] == 3 && mv7[1][4] == 1 &&
+               mv7[2][0] == 7 && mv7[2][1] == 8 && mv7[2][2] == 9,
+               "Failed mvector<2,T> inserting with mvector<1,T> push_back from indirectly accessed within another mvector<2,T>"); 
+
     std::vector<double> v3 = mv2[0];
-    std::vector<double> v4 = mv3[0];
-    ASSERT(mv2.size() == 1 && mv2[0].size() == 3 && mv2[0][0] == 1 && mv2[0][1] == 2 && mv2[0][2] == 3, "Failed mvector<2,T> indexed assign with vector<T> =operator");
-    ASSERT(mv3.size() == 1 && mv3[0].size() == 3 && mv3[0][0] == 1 && mv3[0][1] == 2 && mv3[0][2] == 3, "Failed vector<T> assign with mvector<2,T> push_back");
+    std::vector<double> v4(mv1);
+    std::vector<double> v5(mv2[0]);
+    ASSERT_MSG(v4.size() == 3 && v4[0] == 1 && v4[1] == 2 && v4[2] == 3, 
+               "Failed vector<T> assign with mvector<1,T> iterator constructor");
+    ASSERT_MSG(v5.size() == 3 && v5[0] == 1 && v5[1] == 2 && v5[2] == 3, 
+               "Failed vector<T> assign with indexed mvector<2,T> iterator constructor");
 
-    std::vector<double> v5(mv1);
-    std::vector<double> v6(mv2[0]);
-    ASSERT(v5.size() == 3 && v5[0] == 1 && v5[1] == 2 && v5[2] == 3, "Failed vector<T> assign with mvector<1,T> iterator constructor");
-    ASSERT(v6.size() == 3 && v6[0] == 1 && v6[1] == 2 && v6[2] == 3, "Failed vector<T> assign with indexed mvector<2,T> iterator constructor");
-
-    std::vector<double> v7 = xstd::mvector<1, double>(v11);
-    std::vector<double> v8 = xstd::mvector<1, double>(mv1);
-    xstd::mvector<1, double> mv4 = std::vector<double>(mv1);    
-    ASSERT(v7.size() == 3 && v7[0] == 1 && v7[1] == 2 && v7[2] == 3, "Failed vector<T> assign with mvector<1,T> constructor from other vector<T>");
-    ASSERT(v8.size() == 3 && v8[0] == 1 && v8[1] == 2 && v8[2] == 3, "Failed vector<T> assign with mvector<1,T> constructor from other mvector<1,T>");
-    ASSERT(mv4.size() == 3 && mv4[0] == 1 && mv4[1] == 2 && mv4[2] == 3, "Failed mvector<1,T> assign with vector<T> constructor from other mvector<1,T>");
+    std::vector<double> v6 = xstd::mvector<1, double>(v11);
+    std::vector<double> v7 = xstd::mvector<1, double>(mv1);
+    xstd::mvector<1, double> mv8 = std::vector<double>(mv1);
+    ASSERT_MSG(v6.size() == 3 && v6[0] == 1 && v6[1] == 2 && v6[2] == 3, 
+               "Failed vector<T> assign with mvector<1,T> constructor from other vector<T>");
+    ASSERT_MSG(v7.size() == 3 && v7[0] == 1 && v7[1] == 2 && v7[2] == 3, 
+               "Failed vector<T> assign with mvector<1,T> constructor from other mvector<1,T>");
+    ASSERT_MSG(mv8.size() == 3 && mv8[0] == 1 && mv8[1] == 2 && mv8[2] == 3, 
+               "Failed mvector<1,T> assign with vector<T> constructor from other mvector<1,T>");
 
     std::cout << "All tests passed!" << std::endl;
     std::getchar(); // wait key to allow message visualisation
+
+    return 0;
 }

--- a/examples/mvector_test.cpp
+++ b/examples/mvector_test.cpp
@@ -26,6 +26,13 @@ void main()
     ASSERT(v5.size() == 3 && v5[0] == 1 && v5[1] == 2 && v5[2] == 3, "Failed vector<T> assign with mvector<1,T> iterator constructor");
     ASSERT(v6.size() == 3 && v6[0] == 1 && v6[1] == 2 && v6[2] == 3, "Failed vector<T> assign with indexed mvector<2,T> iterator constructor");
 
+    std::vector<double> v7 = xstd::mvector<1, double>(v11);
+    std::vector<double> v8 = xstd::mvector<1, double>(mv1);
+    xstd::mvector<1, double> mv4 = std::vector<double>(mv1);    
+    ASSERT(v7.size() == 3 && v7[0] == 1 && v7[1] == 2 && v7[2] == 3, "Failed vector<T> assign with mvector<1,T> constructor from other vector<T>");
+    ASSERT(v8.size() == 3 && v8[0] == 1 && v8[1] == 2 && v8[2] == 3, "Failed vector<T> assign with mvector<1,T> constructor from other mvector<1,T>");
+    ASSERT(mv4.size() == 3 && mv4[0] == 1 && mv4[1] == 2 && mv4[2] == 3, "Failed mvector<1,T> assign with vector<T> constructor from other mvector<1,T>");
+
     std::cout << "All tests passed!" << std::endl;
     std::getchar(); // wait key to allow message visualisation
 }

--- a/mvector.hpp
+++ b/mvector.hpp
@@ -149,6 +149,8 @@ namespace xstd {
             }
         }
 
+        mvector<d, T>& operator=(xstd::mvector<d-1, T> mv) { std::swap(*this, mv); return *this; }
+
         public:
         void reshape(size_t n, T const & t = T())
         {
@@ -212,9 +214,8 @@ namespace xstd {
         mvector<1, T>(mshape<1> const & v, T const & t = T()) : std::vector<T>(v.current(), t) {}
         mvector<1, T>(std::vector<T>& other) : std::vector<T>(other) {}
         mvector<1, T>(const std::vector<T>& other) : std::vector<T>(other) {}        
-        mvector<1, T>(std::initializer_list<size_t> ilst, T const & t = T()) : /*mvector<d, T>(ilst.begin(), t)*/ std::vector<T>(*(ilst.begin()), t) {}        
-        const mvector<1, T>  operator=(const std::vector<T>& v) { return mvector<1, T>(v); }
-        const std::vector<T> operator=(const mvector<1, T>& mv) { return std::vector<T>(mv); }
+        mvector<1, T>(std::initializer_list<size_t> ilst, T const & t = T()) : /*mvector<d, T>(ilst.begin(), t)*/ std::vector<T>(*(ilst.begin()), t) {}
+        mvector<1, T>& operator=(std::vector<T> v) { std::swap(*this, v); return *this; }
         private:
         mvector<1, T>(std::initializer_list<size_t> & ilst, std::initializer_list<size_t>::const_iterator ilst_it, T const & t = T()) : std::vector<T>(*ilst_it, t) {}
         public:

--- a/mvector.hpp
+++ b/mvector.hpp
@@ -213,10 +213,10 @@ namespace xstd {
         mvector<1, T>(size_t v[], T const & t = T()) : std::vector<T>(v[0], t) {}
         mvector<1, T>(mshape<1> const & v, T const & t = T()) : std::vector<T>(v.current(), t) {}
         mvector<1, T>(std::vector<T>& other) : std::vector<T>(other) {}
-        mvector<1, T>(const std::vector<T>& other) : std::vector<T>(other) {}
+        mvector<1, T>(const std::vector<T>& other) : std::vector<T>(other) {}        
         mvector<1, T>(std::initializer_list<size_t> ilst, T const & t = T()) : /*mvector<d, T>(ilst.begin(), t)*/ std::vector<T>(*(ilst.begin()), t) {}        
-        const mvector<1, T>& operator=(const std::vector<T>& v) { return mvector<1, T>(v); }
-        const std::vector<T>& operator=(const mvector<1, T>& mv) { return std::vector<T>(mv); }
+        const mvector<1, T>& operator=(std::vector<T>& v) { return mvector<1, T>(v); }
+        //const std::vector<T>& operator=(const mvector<1, T>& mv) { return std::vector<T>(mv); }
         private:
         mvector<1, T>(std::initializer_list<size_t> & ilst, std::initializer_list<size_t>::const_iterator ilst_it, T const & t = T()) : std::vector<T>(*ilst_it, t) {}
         public:

--- a/mvector.hpp
+++ b/mvector.hpp
@@ -24,8 +24,6 @@
 #include <ostream>
 #include <cstdarg>
 
-//#define XSTD_DEBUG
-
 #ifdef XSTD_DEBUG
 #include <iostream>
 #define XSTD_DBGOUT(x) (std::cerr << x << std::endl)
@@ -215,8 +213,8 @@ namespace xstd {
         mvector<1, T>(std::vector<T>& other) : std::vector<T>(other) {}
         mvector<1, T>(const std::vector<T>& other) : std::vector<T>(other) {}        
         mvector<1, T>(std::initializer_list<size_t> ilst, T const & t = T()) : /*mvector<d, T>(ilst.begin(), t)*/ std::vector<T>(*(ilst.begin()), t) {}        
-        const mvector<1, T>& operator=(std::vector<T>& v) { return mvector<1, T>(v); }
-        //const std::vector<T>& operator=(const mvector<1, T>& mv) { return std::vector<T>(mv); }
+        const mvector<1, T>  operator=(const std::vector<T>& v) { return mvector<1, T>(v); }
+        const std::vector<T> operator=(const mvector<1, T>& mv) { return std::vector<T>(mv); }
         private:
         mvector<1, T>(std::initializer_list<size_t> & ilst, std::initializer_list<size_t>::const_iterator ilst_it, T const & t = T()) : std::vector<T>(*ilst_it, t) {}
         public:

--- a/mvector.hpp
+++ b/mvector.hpp
@@ -24,8 +24,6 @@
 #include <ostream>
 #include <cstdarg>
 
-//#define XSTD_DEBUG
-
 #ifdef XSTD_DEBUG
 #include <iostream>
 #define XSTD_DBGOUT(x) (std::cerr << x << std::endl)
@@ -215,8 +213,8 @@ namespace xstd {
         mvector<1, T>(std::vector<T>& other) : std::vector<T>(other) {}
         mvector<1, T>(const std::vector<T>& other) : std::vector<T>(other) {}
         mvector<1, T>(std::initializer_list<size_t> ilst, T const & t = T()) : /*mvector<d, T>(ilst.begin(), t)*/ std::vector<T>(*(ilst.begin()), t) {}        
-        const mvector<1, T>& operator=(const std::vector<T>& v) { return mvector<1, T>(v); }
-        const std::vector<T>& operator=(const mvector<1, T>& mv) { return std::vector<T>(mv); }
+        const mvector<1, T>  operator=(const std::vector<T>& v) { return mvector<1, T>(v); }
+        const std::vector<T> operator=(const mvector<1, T>& mv) { return std::vector<T>(mv); }
         private:
         mvector<1, T>(std::initializer_list<size_t> & ilst, std::initializer_list<size_t>::const_iterator ilst_it, T const & t = T()) : std::vector<T>(*ilst_it, t) {}
         public:


### PR DESCRIPTION
This pull-request fixes an issue that has been identified by employing the `mvector` on one of our cross-platform project. The copy assignment caused an error that silently passed on some platforms, but crashed on others.

The pull request introduces the following changes:

- replace the `operator=` definition for `mvector` by a copy-and-swap idiom so that expected assignment occurs as expected
- multiple new validation tests in `mvector_test.cpp` that evaluate and confirm the changes, including testing higher dimension vectors than before (since there is a distinction between `mvector<1,T>` and `mvector<d,T>` with `d>=2`)
- add `mvector_test` to the makefile to build it automatically
- validated execution of the provided testing procedure with multiple platforms/compilers:
    * Windows - MSVC 14.0 x64 (cl.exe)
    * Windows - TDM-GCC-64 (g++)
    * Ubuntu 16.04 kernel 4.4 (g++)
